### PR TITLE
removing open-vsx.org

### DIFF
--- a/monitors.json
+++ b/monitors.json
@@ -220,10 +220,6 @@
       {
         "component_name": "API Documentation",
         "target": "https://api.eclipse.org/"
-      },
-      {
-        "component_name": "open-vsx.org",
-        "target": "https://open-vsx.org"
       }
     ]
   },


### PR DESCRIPTION
Replaced by https://eclipsefoundation.statuspage.io/