### PR TITLE
Fix Git ECA monitor target

### DIFF
--- a/monitors.json
+++ b/monitors.json
@@ -208,7 +208,7 @@
       },
       {
         "component_name": "ECA API",
-        "target": "https://api.eclipse.org/git/"
+        "target": "https://api.eclipse.org/git/q/health"
       },
       {
         "component_name": "projects.eclipse.org",


### PR DESCRIPTION
Current monitor target took advantage of a bug rather than using a real health/readiness API call. Health endpoints can be seen on any API by adding `/q/health` to any base URL for our microservices.